### PR TITLE
Re-export `esplora_client`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,6 +243,9 @@ pub extern crate bitcoincore_rpc;
 #[cfg(feature = "electrum")]
 pub extern crate electrum_client;
 
+#[cfg(feature = "esplora")]
+pub extern crate esplora_client;
+
 #[cfg(feature = "key-value-db")]
 pub extern crate sled;
 


### PR DESCRIPTION
It would be nice to re-export the Esplora client in order to use its data types.