### PR TITLE
Use upstream master branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rand = "^0.7"
 # Optional dependencies
 sled = { version = "0.34", optional = true }
 electrum-client = { version = "0.10", optional = true }
-esplora-client = { git = "https://github.com/afilini/rust-esplora-client.git", branch = "fix-ureq-version", default-features = false, optional = true }
+esplora-client = { git = "https://github.com/bitcoindevkit/rust-esplora-client.git", branch = "master", default-features = false, optional = true }
 rusqlite = { version = "0.27.0", optional = true }
 ahash = { version = "0.7.6", optional = true }
 futures = { version = "0.3", optional = true }


### PR DESCRIPTION
Since the `ureq` version fix has been merged, this can now use the upstream `master` branch.